### PR TITLE
Fix zsh incompatibility in env.sh

### DIFF
--- a/env.sh.in
+++ b/env.sh.in
@@ -1,11 +1,12 @@
 
-CUTTER_DEPS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+# Use ${(%):-%x}} when BASH_SOURCE is not defined to support sourcing by zsh
+CUTTER_DEPS_ROOT="$( cd "$( dirname "${BASH_SOURCE[0]:-${(%):-%x}}" )" >/dev/null 2>&1 && pwd )"
 
-if [ "${PLATFORM}" == "macos" ]; then
+if [ "${PLATFORM}" = "macos" ]; then
 	export CUTTER_DEPS_PYTHON_FRAMEWORK_DIR="$CUTTER_DEPS_ROOT/python"
 	export CUTTER_DEPS_PYTHON_PREFIX="$CUTTER_DEPS_PYTHON_FRAMEWORK_DIR/Python.framework/Versions/Current"
 	export DYLD_LIBRARY_PATH="$CUTTER_DEPS_ROOT/qt/lib:$CUTTER_DEPS_PYTHON_PREFIX/lib:$CUTTER_DEPS_ROOT/pyside/lib:$LD_LIBRARY_PATH"
-elif [ "${PLATFORM}" == "linux" ]; then
+elif [ "${PLATFORM}" = "linux" ]; then
 	export CUTTER_DEPS_PYTHON_PREFIX="$CUTTER_DEPS_ROOT/python"
 	export LD_LIBRARY_PATH="$CUTTER_DEPS_ROOT/qt/lib:$CUTTER_DEPS_ROOT/python/lib:$CUTTER_DEPS_ROOT/pyside/lib:$LD_LIBRARY_PATH"
 else


### PR DESCRIPTION
In contrast to fetch_deps.sh and relocate.sh, env.sh's shebang doesn't force the script to run in bash because it needs to be sourced to export environment variables. Running a special bash shell to compile cutter isn't very convenient so I went ahead and fixed sourcing for zsh.

Tested with bash and zsh on ubuntu 18.04. The replacement of '==' to '=' adheres to POSIX so it should work in all shells and `${(%):-%x}` is only called in case `BASH_SOURCE` is undefined.

Can also easily fix relocate.sh if you're interested but it's not a breaking issue.