### PR TITLE
Fix paths in shiboeken CMake scripts and package required dlls.

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,16 +10,12 @@ environment:
 build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
   - C:\msys64\usr\bin\bash -lc "
-    mkdir ninja &&
-    cd ninja &&
-    wget https://github.com/ninja-build/ninja/releases/download/v1.9.0/ninja-win.zip &&
-    7z x ninja-win.zip &&
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe &&
+    7z x -oLLVM LLVM-10.0.0-win64.exe &&
+    export LLVM_INSTALL_DIR=\"$PWD/LLVM\" &&
     cd \"%APPVEYOR_BUILD_FOLDER%\" &&
-    export PATH=\"$PWD/ninja:$PWD/qt/bin:$PATH\" &&
-    export LLVM_INSTALL_DIR=\"C:\Program Files\LLVM\" &&
+    export PATH=\"$PWD/qt/bin:$LLVM_INSTALL_DIR/bin:$PATH\" &&
     make PYTHON_WINDOWS=\"C:\Python36-x64\""
-  # make PYTHON_WINDOWS=\"C:\Python36-x64\" QT_PREFIX=\"C:\Qt\5.12\msvc2017_64\""
-  # export PATH=\"$PWD/ninja:/c/Qt/5.12/msvc2017_64/bin:$PATH\" &&
 
 artifacts:
   - path: "%ARTIFACT_PATH%"

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ PYTHON_INCLUDE_DIR=${PYTHON_PREFIX}/include/python3.6m
 PYTHON_EXECUTABLE=${PYTHON_PREFIX}/bin/python3
 else
 PYTHON_PREFIX=${PYTHON_WINDOWS}
-PYTHON_LIBRARY=${PYTHON_WINDOWS}/libs/python36.lib
+PYTHON_LIBRARY=${PYTHON_WINDOWS}/libs/python3.lib
 PYTHON_INCLUDE_DIR=${PYTHON_WINDOWS}/include
 PYTHON_EXECUTABLE=${PYTHON_WINDOWS}/python.exe
 PYTHON_DEPS=
@@ -267,6 +267,11 @@ ${PYSIDE_SRC_DIR}:
 	patch "${PYSIDE_SRC_DIR}/sources/pyside2/CMakeLists.txt" patch/pyside-5.14.1/CMakeLists.txt.patch
 	echo "" > "${PYSIDE_SRC_DIR}/sources/pyside2/cmake/Macros/FindQt5Extra.cmake"
 
+	
+ifeq (${PLATFORM},win)
+	patch "${PYSIDE_SRC_DIR}/sources/shiboken2/ApiExtractor/CMakeLists.txt" patch/lib_install_path.patch
+endif
+
 ifneq (${QT_OPENGL_ENABLED},1)
 	# Patches to remove OpenGL-related source files.
 	patch "${PYSIDE_SRC_DIR}/sources/pyside2/PySide2/QtGui/CMakeLists.txt" patch/pyside-5.12.1/QtGui-CMakeLists.txt.patch
@@ -331,6 +336,7 @@ endif
 ifeq (${PLATFORM},win)
 	cd "${PYSIDE_SRC_DIR}/build/pyside2" && ninja -j ${BUILD_THREADS}
 	cd "${PYSIDE_SRC_DIR}/build/pyside2" && ninja install
+	cp "${LLVM_INSTALL_DIR}/bin/libclang.dll" "${PYSIDE_PREFIX}/bin/"
 else
 	make -C "${PYSIDE_SRC_DIR}/build/pyside2" -j${BUILD_THREADS}
 	make -C "${PYSIDE_SRC_DIR}/build/pyside2" install

--- a/patch/lib_install_path.patch
+++ b/patch/lib_install_path.patch
@@ -1,0 +1,11 @@
+--- sources/shiboken2/ApiExtractor/CMakeLists.txt	2020-08-26 17:37:19.411334400 +0300
++++ sources/shiboken2/ApiExtractor/CMakeLists.txt	2020-08-26 17:36:55.459967400 +0300
+@@ -84,7 +84,7 @@
+ 
+ target_compile_definitions(apiextractor PRIVATE CMAKE_CXX_COMPILER="${CMAKE_CXX_COMPILER}")
+ 
+-set(LIB_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/lib${LIB_SUFFIX}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})" FORCE)
++set(LIB_INSTALL_DIR "lib${LIB_SUFFIX}" CACHE PATH "The subdirectory relative to the install prefix where libraries will be installed (default is /lib${LIB_SUFFIX})" FORCE)
+ 
+ if (BUILD_TESTS)
+     find_package(Qt5Test 5.12 REQUIRED)


### PR DESCRIPTION
<!--- Filling this template is mandatory -->

**Detailed description**

Fix lib install path so that CMake can properly generate movable library targets without absolute paths from build environement

Include libclang.dll on windows so that resulting shiboken can be run on system without appropriate llvm version installed. 

Download LLVM/clang 10 so that it can parse the latest Visual Studio system headers.


**Test plan**

Tested in https://github.com/radareorg/cutter/pull/2406 use the deploy_test build before squashing but the source is identical.

**Closing issues**


