### PR TITLE
Use latest Clang to allow shiboken parsing latest MSVC headers

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -11,7 +11,7 @@ build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
   - C:\msys64\usr\bin\bash -lc "
     wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe &&
-    7z x -oLLVM LLVM-10.0.0-win64.exe &&
+    7z x -oLLVM LLVM-11.0.0-win64.exe &&
     export LLVM_INSTALL_DIR=\"$PWD/LLVM\" &&
     cd \"%APPVEYOR_BUILD_FOLDER%\" &&
     export PATH=\"$PWD/qt/bin:$LLVM_INSTALL_DIR/bin:$PATH\" &&

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -10,7 +10,7 @@ environment:
 build_script:
   - call "C:\Program Files (x86)\Microsoft Visual Studio\2017\Community\VC\Auxiliary\Build\vcvarsall.bat" x64
   - C:\msys64\usr\bin\bash -lc "
-    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-10.0.0/LLVM-10.0.0-win64.exe &&
+    wget https://github.com/llvm/llvm-project/releases/download/llvmorg-11.0.0/LLVM-11.0.0-win64.exe &&
     7z x -oLLVM LLVM-10.0.0-win64.exe &&
     export LLVM_INSTALL_DIR=\"$PWD/LLVM\" &&
     cd \"%APPVEYOR_BUILD_FOLDER%\" &&


### PR DESCRIPTION
<!--- Filling this template is mandatory -->


See https://github.com/radareorg/cutter/issues/2479 . Shiboken can't parse latest MSVC headers. Compiling it against latest Clang (11.0) might help with that.

**Test plan**

Make a PR in cutter repo which uses this and latest appveyor image, all appveyor windows and github actions windows builds should succeed.

**Closing issues**

<!-- put "closes #XXXX" in your comment to auto-close the issue that your PR fixes (if any). -->

...
