### PR TITLE
Use macOS 15 images

### DIFF
--- a/.github/workflows/package-build.yml
+++ b/.github/workflows/package-build.yml
@@ -115,10 +115,10 @@ jobs:
             ]
         include:
           - name: macos-x86_64
-            os: macos-14-large # Must be an x86_64 image: https://github.com/actions/runner-images#available-images
+            os: macos-15-intel # Must be an x86_64 image: https://github.com/actions/runner-images#available-images
             arch: x86_64
           - name: macos-arm64
-            os: macos-14
+            os: macos-15
             arch: arm64
     steps:
     - uses: actions/checkout@v6


### PR DESCRIPTION
macos-14 will unfortunately soon be removed and macos-14-large is also expensive.